### PR TITLE
feat: add OpenCode support to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/head
 
 # For Gemini
 curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini
+
+# For OpenCode
+curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode
 ```
 
 ### Manual Installation
@@ -48,6 +51,7 @@ curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/head
     - **Codex**: `.codex/skills/`
     - **Cursor**: `.cursor/skills/`
     - **Gemini**: `.gemini/skills/`
+    - **OpenCode**: `.opencode/skills/`
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini
+#   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode
 #
 # Copyright (c) Hyva Themes https://hyva.io. All rights reserved.
 # Licensed under the OSL-3.0
@@ -60,12 +61,14 @@ usage() {
     echo "  codex     Install skills for Codex (.codex/skills/)"
     echo "  cursor    Install skills for Cursor (.cursor/skills/)"
     echo "  gemini    Install skills for Gemini (.gemini/skills/)"
+    echo "  opencode  Install skills for OpenCode (.opencode/skills/)"
     echo ""
     echo "Examples:"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s claude"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini"
+    echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode"
     echo ""
     echo "Environment variables:"
     echo "  HYVA_SKILLS_REPO_URL   Custom repository URL"
@@ -87,6 +90,9 @@ get_skills_dir() {
             ;;
         gemini)
             echo ".gemini/skills"
+            ;;
+        opencode)
+            echo ".opencode/skills"
             ;;
         *)
             print_error "Unknown platform: $platform"


### PR DESCRIPTION
This PR adds installation support for OpenCode, following the same pattern as other AI coding assistants (Claude Code, Codex, Cursor, Gemini).

### Changes

- **install.sh**: Added `opencode` as a supported platform with `.opencode/skills/` as the target directory
- **README.md**: Added OpenCode to quick install commands and manual installation instructions

### Usage

Users can now install Hyva AI skills for OpenCode with:

```bash
curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode
