### PR TITLE
add install script for GitHub Copilot skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/head
 # For Codex
 curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex
 
+# For GitHub Copilot
+curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s copilot
+
 # For Cursor
 curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor
 
@@ -50,6 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/head
 2. Copy the skill directories to your project:
     - **Claude Code**: `.claude/skills/`
     - **Codex**: `.codex/skills/`
+    - **GitHub Copilot**: `.github/skills/`
     - **Cursor**: `.cursor/skills/`
     - **Gemini**: `.gemini/skills/`
     - **OpenCode**: `.opencode/skills/`

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s claude
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex
+#   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s copilot
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini
 #   curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode
@@ -59,6 +60,7 @@ usage() {
     echo "Platforms:"
     echo "  claude    Install skills for Claude Code (.claude/skills/)"
     echo "  codex     Install skills for Codex (.codex/skills/)"
+    echo "  copilot   Install skills for GitHub Copilot (.copilot/skills/)"
     echo "  cursor    Install skills for Cursor (.cursor/skills/)"
     echo "  gemini    Install skills for Gemini (.gemini/skills/)"
     echo "  opencode  Install skills for OpenCode (.opencode/skills/)"
@@ -66,6 +68,7 @@ usage() {
     echo "Examples:"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s claude"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex"
+    echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s copilot"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini"
     echo "  curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode"
@@ -84,6 +87,9 @@ get_skills_dir() {
             ;;
         codex)
             echo ".codex/skills"
+            ;;
+        copilot)
+            echo ".github/skills"
             ;;
         cursor)
             echo ".cursor/skills"


### PR DESCRIPTION
This pull request adds support for installing skills for GitHub Copilot in the `hyva-ai-tools` project. The changes update both the installation script and documentation to include Copilot as a supported platform.

**GitHub Copilot support:**

* Added Copilot as a supported platform in the `install.sh` usage instructions and examples. [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR9) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR63-R71)
* Updated the `get_skills_dir()` function in `install.sh` to install Copilot skills into the `.github/skills` directory.

**Documentation updates:**

* Added instructions for installing Copilot skills using the installation script in `README.md`.
* Updated the list of skill directories in `README.md` to include Copilot (`.github/skills/`).