### PR TITLE
Refactor README to improve clarity and organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Replace `claude` with your AI assistant: `codex` · `copilot` · `cursor` · `ge
 1. Clone or download this repository
 2. Copy the `skills/` directory to your project under the appropriate path:
 
-| AI Assistant | Install Path |
-|---|---|
-| Claude Code | `.claude/skills/` |
-| Codex | `.codex/skills/` |
-| GitHub Copilot | `.github/skills/` |
-| Cursor | `.cursor/skills/` |
-| Gemini | `.gemini/skills/` |
-| OpenCode | `.opencode/skills/` |
+| AI Assistant   | Install Path        |
+| -------------- | ------------------- |
+| Claude Code    | `.claude/skills/`   |
+| Codex          | `.codex/skills/`    |
+| GitHub Copilot | `.github/skills/`   |
+| Cursor         | `.cursor/skills/`   |
+| Gemini         | `.gemini/skills/`   |
+| OpenCode       | `.opencode/skills/` |
 
 ## Usage
 
@@ -46,32 +46,32 @@ Once installed, the AI assistant will automatically use these skills when releva
 
 ### Theme & Module Development
 
-| Skill | Description |
-|-------|-------------|
-| [hyva-child-theme](skills/hyva-child-theme/) | Create a Hyva child theme with proper directory structure, Tailwind CSS configuration, and theme inheritance |
-| [hyva-create-module](skills/hyva-create-module/) | Scaffold new Magento 2 modules in `app/code/` |
-| [hyva-alpine-component](skills/hyva-alpine-component/) | Write CSP-compatible Alpine.js components for Hyvä themes following best practices |
-| [hyva-ui-component](skills/hyva-ui-component/) | Install Hyva UI template-based components (headers, footers, galleries, etc.) to themes |
-| [hyva-render-media-image](skills/hyva-render-media-image/) | Generate responsive `<picture>` elements using the Hyva Media view model |
-| [hyva-playwright-test](skills/hyva-playwright-test/) | Write Playwright tests for Hyvä themes with Alpine.js |
+| Skill                                                      | Description                                                                                                  |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [hyva-child-theme](skills/hyva-child-theme/)               | Create a Hyva child theme with proper directory structure, Tailwind CSS configuration, and theme inheritance |
+| [hyva-create-module](skills/hyva-create-module/)           | Scaffold new Magento 2 modules in `app/code/`                                                                |
+| [hyva-alpine-component](skills/hyva-alpine-component/)     | Write CSP-compatible Alpine.js components for Hyvä themes following best practices                           |
+| [hyva-ui-component](skills/hyva-ui-component/)             | Install Hyva UI template-based components (headers, footers, galleries, etc.) to themes                      |
+| [hyva-render-media-image](skills/hyva-render-media-image/) | Generate responsive `<picture>` elements using the Hyva Media view model                                     |
+| [hyva-playwright-test](skills/hyva-playwright-test/)       | Write Playwright tests for Hyvä themes with Alpine.js                                                        |
 
 ### CMS Components
 
-| Skill | Description |
-|-------|-------------|
-| [hyva-cms-component](skills/hyva-cms-component/) | Create custom Hyva CMS components with field presets, variant support, and PHTML templates |
-| [hyva-cms-custom-field](skills/hyva-cms-custom-field/) | Create custom field types and field handlers for Hyvä CMS components |
-| [hyva-cms-components-dump](skills/hyva-cms-components-dump/) | Dump combined JSON of all available Hyvä CMS components from active modules |
+| Skill                                                        | Description                                                                                |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| [hyva-cms-component](skills/hyva-cms-component/)             | Create custom Hyva CMS components with field presets, variant support, and PHTML templates |
+| [hyva-cms-custom-field](skills/hyva-cms-custom-field/)       | Create custom field types and field handlers for Hyvä CMS components                       |
+| [hyva-cms-components-dump](skills/hyva-cms-components-dump/) | Dump combined JSON of all available Hyvä CMS components from active modules                |
 
 ### Utility Skills
 
 > Utility skills are mainly intended to be invoked by other skills, but can also be used directly.
 
-| Skill | Description |
-|-------|-------------|
-| [hyva-compile-tailwind-css](skills/hyva-compile-tailwind-css/) | Compile Tailwind CSS for Hyva themes |
-| [hyva-exec-shell-cmd](skills/hyva-exec-shell-cmd/) | Detect development environment (Warden, docker-magento, local) and execute commands with appropriate wrappers |
-| [hyva-theme-list](skills/hyva-theme-list/) | List all Hyva theme paths in a Magento 2 project |
+| Skill                                                          | Description                                                                                                   |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| [hyva-compile-tailwind-css](skills/hyva-compile-tailwind-css/) | Compile Tailwind CSS for Hyva themes                                                                          |
+| [hyva-exec-shell-cmd](skills/hyva-exec-shell-cmd/)             | Detect development environment (Warden, docker-magento, local) and execute commands with appropriate wrappers |
+| [hyva-theme-list](skills/hyva-theme-list/)                     | List all Hyva theme paths in a Magento 2 project                                                              |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,63 +1,35 @@
 # Hyva AI Skills
 
-AI-powered skills for Magento 2 development with Hyva Theme. These skills extend AI coding assistants with specialized
-knowledge for creating Hyva themes, modules, and CMS components.
-
-## Available Skills
-
-| Skill                                                          | Description                                                                                                                     |
-|----------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| [hyva-alpine-component](skills/hyva-alpine-component/)         | Write CSP-compatible Alpine.js components for Hyvä themes following best practices                                               |
-| [hyva-child-theme](skills/hyva-child-theme/)                   | Create a Hyva child theme with proper directory structure, Tailwind CSS configuration, and theme inheritance                    |
-| [hyva-cms-component](skills/hyva-cms-component/)               | Create custom Hyva CMS components with field presets, variant support, and PHTML templates                                      |
-| [hyva-cms-components-dump](skills/hyva-cms-components-dump/)   | Dump combined JSON of all available Hyvä CMS components from active modules                                                     |
-| [hyva-cms-custom-field](skills/hyva-cms-custom-field/)         | Create custom field types and field handlers for Hyvä CMS components                                                            |
-| [hyva-compile-tailwind-css](skills/hyva-compile-tailwind-css/) | Utility skill to compile Tailwind CSS for Hyva themes                                                                           |
-| [hyva-create-module](skills/hyva-create-module/)               | Scaffold new Magento 2 modules in app/code/                                                                                     |
-| [hyva-exec-shell-cmd](skills/hyva-exec-shell-cmd/)             | Utility skill to detect development environment (Warden, docker-magento, local) and execute commands with appropriate wrappers  |
-| [hyva-playwright-test](skills/hyva-playwright-test/)           | Write Playwright tests for Hyvä themes with Alpine.js                                                                           |
-| [hyva-render-media-image](skills/hyva-render-media-image/)     | Generate responsive `<picture>` elements using the Hyva Media view model                                                        |
-| [hyva-theme-list](skills/hyva-theme-list/)                     | List all Hyva theme paths in a Magento 2 project                                                                                |
-| [hyva-ui-component](skills/hyva-ui-component/)                 | Install Hyva UI template-based components (headers, footers, galleries, etc.) to themes                                         |
-
-"Utility skills" are mainly intended to be invoked by other skills, but can of course also be used directly.
+AI-powered skills for Magento 2 development with Hyva Theme.
+These skills extend AI coding assistants with specialized knowledge for creating Hyva themes,
+modules, and CMS components.
 
 ## Installation
 
-Always install all skills together, as they often refer to each other.
+> [!NOTE]
+> Always install all skills together, as they often refer to each other.
 
 ### Quick Install
 
 ```bash
-# For Claude Code
 curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s claude
-
-# For Codex
-curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s codex
-
-# For GitHub Copilot
-curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s copilot
-
-# For Cursor
-curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s cursor
-
-# For Gemini
-curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s gemini
-
-# For OpenCode
-curl -fsSL https://raw.githubusercontent.com/hyva-themes/hyva-ai-tools/refs/heads/main/install.sh | sh -s opencode
 ```
+
+Replace `claude` with your AI assistant: `codex` · `copilot` · `cursor` · `gemini` · `opencode`
 
 ### Manual Installation
 
 1. Clone or download this repository
-2. Copy the skill directories to your project:
-    - **Claude Code**: `.claude/skills/`
-    - **Codex**: `.codex/skills/`
-    - **GitHub Copilot**: `.github/skills/`
-    - **Cursor**: `.cursor/skills/`
-    - **Gemini**: `.gemini/skills/`
-    - **OpenCode**: `.opencode/skills/`
+2. Copy the `skills/` directory to your project under the appropriate path:
+
+| AI Assistant | Install Path |
+|---|---|
+| Claude Code | `.claude/skills/` |
+| Codex | `.codex/skills/` |
+| GitHub Copilot | `.github/skills/` |
+| Cursor | `.cursor/skills/` |
+| Gemini | `.gemini/skills/` |
+| OpenCode | `.opencode/skills/` |
 
 ## Usage
 
@@ -68,6 +40,38 @@ Once installed, the AI assistant will automatically use these skills when releva
 - "Add a CMS component for a hero banner"
 - "Compile Tailwind CSS"
 - "Apply the gallery component from Hyva UI"
+- `/hyva-child-theme` (explicit slash command invocation)
+
+## Available Skills
+
+### Theme & Module Development
+
+| Skill | Description |
+|-------|-------------|
+| [hyva-child-theme](skills/hyva-child-theme/) | Create a Hyva child theme with proper directory structure, Tailwind CSS configuration, and theme inheritance |
+| [hyva-create-module](skills/hyva-create-module/) | Scaffold new Magento 2 modules in `app/code/` |
+| [hyva-alpine-component](skills/hyva-alpine-component/) | Write CSP-compatible Alpine.js components for Hyvä themes following best practices |
+| [hyva-ui-component](skills/hyva-ui-component/) | Install Hyva UI template-based components (headers, footers, galleries, etc.) to themes |
+| [hyva-render-media-image](skills/hyva-render-media-image/) | Generate responsive `<picture>` elements using the Hyva Media view model |
+| [hyva-playwright-test](skills/hyva-playwright-test/) | Write Playwright tests for Hyvä themes with Alpine.js |
+
+### CMS Components
+
+| Skill | Description |
+|-------|-------------|
+| [hyva-cms-component](skills/hyva-cms-component/) | Create custom Hyva CMS components with field presets, variant support, and PHTML templates |
+| [hyva-cms-custom-field](skills/hyva-cms-custom-field/) | Create custom field types and field handlers for Hyvä CMS components |
+| [hyva-cms-components-dump](skills/hyva-cms-components-dump/) | Dump combined JSON of all available Hyvä CMS components from active modules |
+
+### Utility Skills
+
+> Utility skills are mainly intended to be invoked by other skills, but can also be used directly.
+
+| Skill | Description |
+|-------|-------------|
+| [hyva-compile-tailwind-css](skills/hyva-compile-tailwind-css/) | Compile Tailwind CSS for Hyva themes |
+| [hyva-exec-shell-cmd](skills/hyva-exec-shell-cmd/) | Detect development environment (Warden, docker-magento, local) and execute commands with appropriate wrappers |
+| [hyva-theme-list](skills/hyva-theme-list/) | List all Hyva theme paths in a Magento 2 project |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Once installed, the AI assistant will automatically use these skills when releva
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
 | [hyva-cms-component](skills/hyva-cms-component/)             | Create custom Hyva CMS components with field presets, variant support, and PHTML templates |
 | [hyva-cms-custom-field](skills/hyva-cms-custom-field/)       | Create custom field types and field handlers for Hyvä CMS components                       |
-| [hyva-cms-components-dump](skills/hyva-cms-components-dump/) | Dump combined JSON of all available Hyvä CMS components from active modules                |
 
 ### Utility Skills
 
@@ -72,6 +71,7 @@ Once installed, the AI assistant will automatically use these skills when releva
 | [hyva-compile-tailwind-css](skills/hyva-compile-tailwind-css/) | Compile Tailwind CSS for Hyva themes                                                                          |
 | [hyva-exec-shell-cmd](skills/hyva-exec-shell-cmd/)             | Detect development environment (Warden, docker-magento, local) and execute commands with appropriate wrappers |
 | [hyva-theme-list](skills/hyva-theme-list/)                     | List all Hyva theme paths in a Magento 2 project                                                              |
+| [hyva-cms-components-dump](skills/hyva-cms-components-dump/) | Dump combined JSON of all available Hyvä CMS components from active modules                |
 
 ## License
 


### PR DESCRIPTION
The README has been restructured to group skills by category (Theme & Module Development, CMS Components, Utility Skills). Installation instructions have been clarified with a table format for manual installation paths. Usage examples now include explicit slash command invocation. A note about installing skills together has been emphasized with a blockquote.

---

_Note for PR #5_ these added skills in the PR can be grouped under `Theme & Module Development`