### PR TITLE
Removed circular dependency

### DIFF
--- a/skills/hyva-compile-tailwind-css/SKILL.md
+++ b/skills/hyva-compile-tailwind-css/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hyva-compile-tailwind-css
 description: Compile Tailwind CSS for Hyvä themes in Magento 2. Use when the user wants to build styles, generate CSS, compile Tailwind, run Tailwind, or create production/development stylesheets for a Hyvä theme. Also use when Tailwind classes are not taking effect or some styles appear missing after template changes — this typically means CSS needs to be recompiled. Triggers include "compile tailwind", "build styles", "generate css", "styles not working", "styles are missing", "styles not applied".
-requires: hyva-exec-shell-cmd, hyva-theme-list, hyva-child-theme
+requires: hyva-exec-shell-cmd, hyva-theme-list
 ---
 
 # Compile Tailwind CSS for Hyvä Themes


### PR DESCRIPTION
Encountered an error during installation:
Installation failed due to a circular dependency in skill metadata:

-  hyva-child-theme → hyva-compile-tailwind-css → hyva-child-theme

Fixed circular dependency by removing hyva-child-theme from hyva-compile-tailwind-css's  requires 